### PR TITLE
Improve service start order control and syslog logging for all rocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dockers/*/Dockerfile-dbg.cleanup
 dockers/*/debs
 dockers/*/files
 dockers/*/python-wheels
+dockers/*/*supervisor.conf.real
 dockers/*/*supervisord.conf.real
 platform/*/docker-*/Dockerfile
 platform/*/docker-*/Dockerfile.cleanup

--- a/build_rocks.sh
+++ b/build_rocks.sh
@@ -18,8 +18,8 @@ rocklist=(
 		"dockers/docker-eventd" \
 		"dockers/docker-sflow" \
 		"dockers/docker-snmp" \
-		"platform/vs/docker-syncd-vs" \
-		"platform/vs/docker-gbsyncd-vs"\
+		# "platform/vs/docker-syncd-vs" \
+		# "platform/vs/docker-gbsyncd-vs"\
 		"platform/broadcom/docker-syncd-brcm" \
         )
 

--- a/build_rocks.sh
+++ b/build_rocks.sh
@@ -18,14 +18,15 @@ rocklist=(
 		"dockers/docker-eventd" \
 		"dockers/docker-sflow" \
 		"dockers/docker-snmp" \
-		# "platform/vs/docker-syncd-vs" \
-		# "platform/vs/docker-gbsyncd-vs"\
+		"platform/vs/docker-syncd-vs" \
+		"platform/vs/docker-gbsyncd-vs"\
 		"platform/broadcom/docker-syncd-brcm" \
         )
 
 cp files/rsyslog/00-load-omprog.conf target/files/noble/
 cp files/rsyslog/rsyslog.conf target/files/noble/
 cp files/supervisor/supervisord.conf target/files/noble/
+cp files/build_templates/syslog-layer.yaml target/files/noble
 set -x
 set -e
 

--- a/dockers/docker-database/rock-database-init.sh
+++ b/dockers/docker-database/rock-database-init.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -134,3 +121,6 @@ done
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start redis
+pebble start flushdb

--- a/dockers/docker-database/rockcraft.yaml
+++ b/dockers/docker-database/rockcraft.yaml
@@ -11,25 +11,21 @@ license: Apache-2.0
 platforms:
   amd64:
 
-# TODO investigate the use of checks to restart services
 services:
   init:
-    command: bash -c "rock-database-init.sh && touch /tmp/init_ok"
+    command: rock-database-init.sh
     override: replace
     startup: enabled
     on-success: ignore
   redis:
-    command: bash -c "test -f /tmp/init_ok && { [[ -s /var/lib/redis/dump.rdb ]] || rm -f /var/lib/redis/dump.rdb; } && mkdir -p /var/lib/redis && exec /usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1 --port 6379 --unixsocket /var/run/redis/redis.sock --pidfile /var/run/redis/redis.pid --dir /var/lib/redis"
+    command: bash -c "{ [[ -s /var/lib/redis/dump.rdb ]] || rm -f /var/lib/redis/dump.rdb; } && mkdir -p /var/lib/redis && exec /usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1 --port 6379 --unixsocket /var/run/redis/redis.sock --pidfile /var/run/redis/redis.pid --dir /var/lib/redis"
     override: replace
-    startup: enabled
   flushdb:
     command: bash -c "sleep 300 && /usr/local/bin/flush_unused_database"
     override: replace
-    startup: enabled
     on-success: ignore
     on-failure: ignore
-    after: [ redis ]
-    requires: [ redis ]
+
 parts:
   setup-database:
     plugin: dump
@@ -63,6 +59,7 @@ parts:
     organize:
       database_config.json.j2: usr/share/sonic/templates/database_config.json.j2
       database_global.json.j2: usr/share/sonic/templates/database_global.json.j2
+      files/syslog-layer.yaml: usr/share/sonic/templates/
       rock-database-init.sh: usr/local/bin/rock-database-init.sh
       files/container_startup.py: usr/share/sonic/scripts/container_startup.py
       files/readiness_probe.sh: usr/bin/readiness_probe.sh

--- a/dockers/docker-eventd/rockcraft.yaml
+++ b/dockers/docker-eventd/rockcraft.yaml
@@ -17,15 +17,14 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   eventd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/eventd"
+    command: /usr/bin/eventd
     override: replace
-    startup: enabled
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 
@@ -125,7 +124,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -146,16 +146,3 @@ parts:
       # docker-teamd specifc
       mkdir -p usr/bin
       cp ${CRAFT_PROJECT_DIR}/start.sh                 usr/bin/
-      
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-eventd/start.sh
+++ b/dockers/docker-eventd/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -24,3 +11,5 @@ fi
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start eventd

--- a/dockers/docker-lldp/rockcraft.yaml
+++ b/dockers/docker-lldp/rockcraft.yaml
@@ -123,6 +123,7 @@ parts:
       - libnl-genl-3-200
       - libnl-nf-3-200
       - libnl-cli-3-200
+      - socat
 
   install-python:
     plugin: python
@@ -196,3 +197,14 @@ parts:
       mkdir etc/default
       cp ${CRAFT_PROJECT_DIR}/lldpd                   etc/default/
       cp ${CRAFT_PROJECT_DIR}/lldpmgrd                usr/bin
+
+  add-user:
+    plugin: nil
+    after: [install-common-files]
+    overlay-script: |
+      #syslog user
+      groupadd -R $CRAFT_OVERLAY _lldpd
+      useradd -R $CRAFT_OVERLAY -M -r --system -g _lldpd _lldpd
+    prime:
+      - etc/passwd
+      - etc/group

--- a/dockers/docker-lldp/rockcraft.yaml
+++ b/dockers/docker-lldp/rockcraft.yaml
@@ -202,7 +202,6 @@ parts:
     plugin: nil
     after: [install-common-files]
     overlay-script: |
-      #syslog user
       groupadd -R $CRAFT_OVERLAY _lldpd
       useradd -R $CRAFT_OVERLAY -M -r --system -g _lldpd _lldpd
     prime:

--- a/dockers/docker-macsec/rockcraft.yaml
+++ b/dockers/docker-macsec/rockcraft.yaml
@@ -17,15 +17,14 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore    
   macsecmgrd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/macsecmgrd"
+    command: /usr/bin/macsecmgrd
     override: replace
-    startup: enabled
 
 # FROM docker-swss-layer-noble 
 
@@ -170,7 +169,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -193,16 +193,3 @@ parts:
 
       mkdir -p cli
       cp -r ${CRAFT_PROJECT_DIR}/cli/*   cli/
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-macsec/start.sh
+++ b/dockers/docker-macsec/start.sh
@@ -1,22 +1,11 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start macsecmgrd

--- a/dockers/docker-nat/rockcraft.yaml
+++ b/dockers/docker-nat/rockcraft.yaml
@@ -17,29 +17,22 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   natmgrd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/natmgrd"
+    command: /usr/bin/natmgrd
     override: replace
-    startup: enabled
   natsyncd:
     command: /usr/bin/natsyncd
     override: replace
-    startup: enabled
-    after: [ natmgrd ]
-    requires: [ natmgrd ]
   restore_nat_entries:
     command: /usr/bin/restore_nat_entries.py
     override: replace
-    startup: enabled
     on-success: ignore
     on-failure: ignore
-    after: [ natsyncd ]
-    requires: [ natsyncd ]
 
 # FROM docker-swss-layer-noble 
 
@@ -211,6 +204,7 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
  
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
@@ -244,16 +238,3 @@ parts:
       ln -s ebtables-nft           ${CRAFT_PRIME}/usr/sbin/ebtables
       ln -s ebtables-nft-restore   ${CRAFT_PRIME}/usr/sbin/ebtables-restore
       ln -s ebtables-nft-save      ${CRAFT_PRIME}/usr/sbin/ebtables-save
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-nat/start.sh
+++ b/dockers/docker-nat/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -24,3 +11,7 @@ mkdir -p /var/warmboot/nat
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start natmgrd
+pebble start natsyncd
+pebble start restore_nat_entries

--- a/dockers/docker-sflow/rockcraft.yaml
+++ b/dockers/docker-sflow/rockcraft.yaml
@@ -17,19 +17,17 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   sflowmgrd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/sflowmgrd"
+    command: /usr/bin/sflowmgrd
     override: replace
-    startup: enabled
   port_index_mapper:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/port_index_mapper.py"
+    command: /usr/bin/port_index_mapper.py
     override: replace
-    startup: enabled
     on-failure: ignore
     on-success: ignore
 
@@ -187,6 +185,7 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
 
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
@@ -207,16 +206,3 @@ parts:
       mkdir -p usr/bin
       cp ${CRAFT_PROJECT_DIR}/start.sh                usr/bin/
       cp ${CRAFT_PROJECT_DIR}/port_index_mapper.py    usr/bin/
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-sflow/start.sh
+++ b/dockers/docker-sflow/start.sh
@@ -1,22 +1,12 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start sflowmgrd
+pebble start port_index_mapper

--- a/dockers/docker-snmp/rockcraft.yaml
+++ b/dockers/docker-snmp/rockcraft.yaml
@@ -17,22 +17,23 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
+    override: replace
+    startup: enabled
+    on-success: ignore
+    on-failure: ignore
+  fake-syslog-socket:
+    command: socat -u UNIX-RECV:/dev/log,mode=666,reuseaddr OPEN:/dev/null,append
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   snmpd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/sbin/snmpd -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid"
+    command: /usr/sbin/snmpd -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
     override: replace
-    startup: enabled
   snmp-subagent:
     command: /usr/bin/env python3 -m sonic_ax_impl
     override: replace
-    startup: enabled
-    after: [ snmpd ]
-    requires: [ snmpd ]
-
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 
@@ -121,6 +122,7 @@ parts:
       - libnl-genl-3-200
       - libnl-nf-3-200
       - libnl-cli-3-200
+      - socat
 
   install-python:
     plugin: python
@@ -165,7 +167,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -192,15 +195,12 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/sysDescription.j2        usr/share/sonic/templates/
 
       # EXPOSE 161/udp 162/udp
+  
   add-user:
     plugin: nil
     after: [install-common-files]
 
     overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
       #snmp user
       groupadd -R $CRAFT_OVERLAY Debian-snmp
       useradd -R $CRAFT_OVERLAY -M -r --system -g Debian-snmp Debian-snmp

--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -47,3 +34,6 @@ echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start snmpd
+pebble start snmp-subagent

--- a/dockers/docker-sonic-gnmi/rockcraft.yaml
+++ b/dockers/docker-sonic-gnmi/rockcraft.yaml
@@ -17,23 +17,19 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   gnmi-native:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/gnmi-native.sh"
+    command: /usr/bin/gnmi-native.sh
     override: replace
-    startup: enabled
   dialout:
     command: /usr/bin/dialout.sh
     override: replace
-    startup: enabled
     on-failure: ignore
     on-success: ignore
-    after: [ gnmi-native ]
-    requires: [ gnmi-native ]
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 
@@ -105,8 +101,6 @@ parts:
       - libnl-nf-3-200
       - libnl-cli-3-200
 
-
-
   install-python:
     plugin: python
     source: .
@@ -147,6 +141,7 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
 
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
@@ -172,16 +167,3 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/dialout.sh                usr/bin/
 
       cp ${CRAFT_PROJECT_DIR}/telemetry_vars.j2         usr/share/sonic/templates/
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-sonic-gnmi/start.sh
+++ b/dockers/docker-sonic-gnmi/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -22,6 +9,9 @@ if [ "${RUNTIME_OWNER}" == "" ]; then
 fi
 
 CTR_SCRIPT="/usr/share/sonic/scripts/container_startup.py"
+echo RUNTIME_OWNER=${RUNTIME_OWNER}, IMAGE_VERSION=${IMAGE_VERSION}
+echo CTR_SCRIPT=$(ls ${CTR_SCRIPT})
+
 if test -f ${CTR_SCRIPT}
 then
     ${CTR_SCRIPT} -f gnmi -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}
@@ -33,3 +23,6 @@ echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start gnmi-native
+pebble start dialout

--- a/dockers/docker-sonic-gnmi/start.sh
+++ b/dockers/docker-sonic-gnmi/start.sh
@@ -9,9 +9,6 @@ if [ "${RUNTIME_OWNER}" == "" ]; then
 fi
 
 CTR_SCRIPT="/usr/share/sonic/scripts/container_startup.py"
-echo RUNTIME_OWNER=${RUNTIME_OWNER}, IMAGE_VERSION=${IMAGE_VERSION}
-echo CTR_SCRIPT=$(ls ${CTR_SCRIPT})
-
 if test -f ${CTR_SCRIPT}
 then
     ${CTR_SCRIPT} -f gnmi -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}

--- a/dockers/docker-sonic-mgmt-framework/rockcraft.yaml
+++ b/dockers/docker-sonic-mgmt-framework/rockcraft.yaml
@@ -17,15 +17,14 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   rest-server:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/rest-server.sh"
+    command: /usr/bin/rest-server.sh
     override: replace
-    startup: enabled
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 
@@ -141,7 +140,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -165,16 +165,3 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/rest-server.sh            usr/bin/
 
       cp ${CRAFT_PROJECT_DIR}/mgmt_vars.j2              usr/share/sonic/templates/
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-sonic-mgmt-framework/start.sh
+++ b/dockers/docker-sonic-mgmt-framework/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -23,3 +10,5 @@ echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start rest-server

--- a/dockers/docker-teamd/rockcraft.yaml
+++ b/dockers/docker-teamd/rockcraft.yaml
@@ -17,25 +17,20 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
     on-failure: ignore
   teammgrd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/teammgrd"
+    command: /usr/bin/teammgrd
     override: replace
-    startup: enabled
   tlm_teamd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/tlm_teamd"
+    command: /usr/bin/tlm_teamd
     override: replace
-    startup: enabled
   teamsyncd:
     command: /usr/bin/teamsyncd
     override: replace
-    startup: enabled
-    after: [ teammgrd ]
-    requires: [ teammgrd ]
 
 # FROM docker-swss-layer-noble 
 
@@ -183,7 +178,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -202,16 +198,3 @@ parts:
       # docker-teamd specifc
       mkdir -p usr/bin
       cp ${CRAFT_PROJECT_DIR}/start.sh usr/bin/
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -24,3 +11,7 @@ mkdir -p /var/warmboot/teamd
 TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+pebble start teammgrd
+pebble start tlm_teamd
+pebble start teamsyncd

--- a/platform/broadcom/docker-syncd-brcm/rockcraft.yaml
+++ b/platform/broadcom/docker-syncd-brcm/rockcraft.yaml
@@ -4,7 +4,7 @@ description: A Chiselled rock for SONiC broadcom syncd container
 version: "1.0.0"
 
 # Use a "bare" base for an even smaller rock
-base: ubuntu@24.04 
+base: ubuntu@24.04
 
 # Meeting requirement R1 by making sure the rock builds on Jammy
 build-base: ubuntu@24.04
@@ -17,22 +17,18 @@ platforms:
 
 services:
   start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
+    command: /usr/bin/start.sh
     override: replace
     startup: enabled
     on-success: ignore
   syncd:
-    command: bash -c "test -f /tmp/start_ok && exec /usr/bin/syncd_start.sh"
+    command: /usr/bin/syncd_start.sh
     override: replace
-    startup: enabled
   ledinit:
     command: /usr/bin/start_led.sh
     override: replace
-    startup: enabled
     on-success: ignore
     on-failure: ignore
-    after: [ syncd ]
-    requires: [ syncd ]
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 
@@ -159,7 +155,8 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/files/swss_vars.j2         usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/files/readiness_probe.sh   usr/bin/
       cp ${CRAFT_PROJECT_DIR}/files/container_startup.py usr/share/sonic/scripts/
- 
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml    usr/share/sonic/templates/
+
       # common - supervisor config files
       mkdir -p etc/supervisor/conf.d
       mkdir -p var/log/supervisor
@@ -181,22 +178,3 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/start.sh                usr/bin/
       cp ${CRAFT_PROJECT_DIR}/start_led.sh            usr/bin/
       cp ${CRAFT_PROJECT_DIR}/bcmsh                   usr/bin/
-
-      # TODO: to be removed after pebble syslog version has released
-      rm -f ${CRAFT_PRIME}/bin/pebble
-      rm -f ${CRAFT_PRIME}/usr/bin/pebble
-      curl -o ${CRAFT_PRIME}/usr/bin/pebble 10.239.7.20:8080/pebble
-      chmod +x ${CRAFT_PRIME}/usr/bin/pebble
-
-  add-user:
-    plugin: nil
-    after: [install-common-files]
-
-    overlay-script: |
-      #syslog user
-      groupadd -R $CRAFT_OVERLAY syslog
-      useradd -R $CRAFT_OVERLAY -M -r --system -g adm syslog
-
-    prime:
-      - etc/passwd
-      - etc/group

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
-
-LAYER_FILE="/tmp/syslog-layer.yaml"
-
-echo "
-log-targets:
-  host-syslog:
-    override: replace
-    type: syslog
-    location: udp://127.0.0.1:514/
-    services: [all]
-" > $LAYER_FILE
-
-echo "File created: $LAYER_FILE"
-echo "Service Dependency: $DEPENDENCY"
-echo "---"
+set -e
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
@@ -46,3 +33,6 @@ else
         cp $HWSKU_DIR/sai.profile /etc/sai.d/sai.profile
     fi
 fi
+
+pebble start syncd
+pebble start ledinit || true

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+
 LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
 pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
@@ -35,4 +35,4 @@ else
 fi
 
 pebble start syncd
-pebble start ledinit || true
+pebble start ledinit


### PR DESCRIPTION
This PR does the following to all rocks:
- Use `pebble start` in the start script to control service start order, instead of `after` and `requires` keywords in rockcraft.yaml
- Get rid of the flag files, which served as workaround of service order control (mentioned in https://github.com/canonical/pebble/issues/712)
- Add `fake-syslog-socket` service for those rocks which requires to write to syslog socket (/dev/log) to run
- Put pebble syslog layer filer into a separate file, instead of inline string in start scripts
- Remove syslog user in rockcraft.yaml