### PR TITLE
Read from redis for fpm-frr & add missing services for orchagent

### DIFF
--- a/dockers/docker-fpm-frr/rock_init.sh
+++ b/dockers/docker-fpm-frr/rock_init.sh
@@ -115,8 +115,6 @@ TZ=$(cat /etc/timezone)
 rm -rf /etc/localtime
 ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
 
-# exec /usr/local/bin/supervisord
-
 pebble start zebra
 /usr/bin/zsocket.sh
 pebble start staticd
@@ -124,7 +122,7 @@ pebble start bgpd
 pebble start fpmsyncd
 
 SUPERVISORD_FILE_PATH="/etc/supervisor/conf.d/supervisord.conf"
-if grep -q "\[program:bfdd\]" $SUPERVISORD_FILE_PATH; then
+if $(sonic-cfggen -d -v DEVICE_METADATA.localhost.frr_mgmt_framework_config) == "true"; then
     pebble start bfdd
     pebble start ospfd
     pebble start pimd
@@ -135,7 +133,8 @@ else
     pebble start bgpmon
 fi
 
-if grep -q "\[program:vtysh_b\]" $SUPERVISORD_FILE_PATH; then
+routing_config_mode=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.docker_routing_config_mode)
+if [[ $routing_config_mode == "unified" ]] || [[ $routing_config_mode == "split-unified" ]]; then
     pebble start vtysh_b
 fi
 

--- a/dockers/docker-orchagent/rock-orchagent-init.sh
+++ b/dockers/docker-orchagent/rock-orchagent-init.sh
@@ -4,7 +4,6 @@ pebble add syslog-layer --combine $LAYER_FILE
 pebble replan
 
 mkdir -p /etc/swss/config.d/
-mkdir -p /etc/supervisor/
 mkdir -p /etc/supervisor/conf.d/
 
 
@@ -19,7 +18,7 @@ CFGGEN_PARAMS=" \
     -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes \
     -t /usr/share/sonic/templates/watchdog_processes.j2,/etc/supervisor/watchdog_processes \
-    -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf
+    -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/wait_for_link.sh.j2,/usr/bin/wait_for_link.sh \
 "
 VLAN=$(sonic-cfggen $CFGGEN_PARAMS)
@@ -79,6 +78,9 @@ if [[ $SWITCH_TYPE != "fabric" ]]; then
     pebble start portsyncd
 fi
 
+if [ "$VLAN" != "" ]; then
+    echo $VLAN > /tmp/vlan
+fi
 pebble start orchagent
 pebble start gearsyncd
 pebble start swssconfig

--- a/dockers/docker-orchagent/rockcraft.yaml
+++ b/dockers/docker-orchagent/rockcraft.yaml
@@ -163,6 +163,16 @@ services:
       IMAGENAME: "docker-orchagent"
       DISTRO: "noble"
 
+  arp_update:
+    command: /usr/bin/arp_update
+    override: replace
+  ndppd:
+    command: /usr/sbin/ndppd
+    override: replace
+  tunnel_packet_handler:
+    command: /usr/bin/tunnel_packet_handler.py
+    override: replace
+
 # FROM docker-swss-layer-noble 
 
 parts:

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -84,3 +84,16 @@ if [[ $SWITCH_TYPE != "fabric" ]]; then
     pebble start tunnelmgrd
     pebble start fdbsyncd
 fi
+
+if [[ -s /tmp/vlan ]] || [[ "$SWITCH_TYPE" == "chassis-packet" ]]; then
+    pebble start arp_update
+fi
+if [ -s /tmp/vlan ]; then
+    /usr/bin/wait_for_link.sh
+    pebble start ndppd
+fi
+
+SUBTYPE=$(sonic-db-cli -s CONFIG_DB HGET 'DEVICE_METADATA|localhost' 'subtype')
+if [ "$SUBTYPE" == "DualToR" ]; then
+    pebble start tunnel_packet_handler
+fi

--- a/dockers/docker-orchagent/wait_for_link.sh.j2
+++ b/dockers/docker-orchagent/wait_for_link.sh.j2
@@ -28,3 +28,5 @@ function wait_until_iface_ready
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 wait_until_iface_ready ${VLAN_TABLE_PREFIX} {{ name }}
 {% endfor %}
+
+pebble start ndppd


### PR DESCRIPTION
This PR does the following:

- Add three missing services for orchagent rock: arp_update, ndppd, tunnel_packet_handler. The corresponding supervisord services were added dynamically by `init.sh` into `/etc/supervisor/conf.d` , instead of `/etc/supervisor/supervisord.conf`.

- In rock fpm-frr's init script, use `sonic-cfggen` to read config from redis and decide which service to run, rather than reading generated supervisord.conf. Because supervisord process has already been removed and its config files may be removed in the future. 