### PR TITLE
Build broadcom instead of vs image in daily workflow

### DIFF
--- a/.github/testflinger/build_brcm_on_feature_noble_build.yaml
+++ b/.github/testflinger/build_brcm_on_feature_noble_build.yaml
@@ -20,12 +20,17 @@ test_data:
     ssh ubuntu@$DEVICE_IP pip3 install -q --user j2cli > /dev/null
     ssh ubuntu@$DEVICE_IP pip3 install -q --user jinjanator > /dev/null
 
-    # 2. Build vs image target
+    # 2. Build broadcom image
     ssh ubuntu@$DEVICE_IP git clone -q -b feature_noble_build --recurse-submodules https://github.com/canonical/sonic-buildimage.git > /dev/null
     ssh ubuntu@$DEVICE_IP sudo modprobe overlay
     ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && make init"
-    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && MIRROR_SECURITY_URLS=http://mirror.csclub.uwaterloo.ca/ubuntu/ MIRROR_URLS=http://mirror.csclub.uwaterloo.ca/ubuntu/ make configure PLATFORM=vs"
-    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && DBGOPT=1 SONIC_BUILD_RETRY_COUNT=15 make SONIC_BUILD_JOBS=4 all"
+    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && MIRROR_SECURITY_URLS=http://mirror.csclub.uwaterloo.ca/ubuntu/ MIRROR_URLS=http://mirror.csclub.uwaterloo.ca/ubuntu/ make configure PLATFORM=broadcom"
+    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && DBGOPT=1 SONIC_BUILD_RETRY_COUNT=15 make SONIC_BUILD_JOBS=4 target/sonic-broadcom.bin"
+    
+    # 3. Build rocks and rebuild broadcom image
+    ssh ubuntu@$DEVICE_IP "rm /home/ubuntu/sonic-buildimage/target/sonic-broadcom.bin"
+    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && ./build_rocks.sh"
+    ssh ubuntu@$DEVICE_IP "cd /home/ubuntu/sonic-buildimage && SONIC_BUILD_RETRY_COUNT=15 make SONIC_BUILD_JOBS=4 target/sonic-broadcom.bin"
 
 output_timeout: 1800  # 30min
 global_timeout: 86400 # 24hours

--- a/.github/workflows/build_brcm.yml
+++ b/.github/workflows/build_brcm.yml
@@ -1,4 +1,4 @@
-name: Build vs target on feature_noble_build branch
+name: Build brcm image on feature_noble_build branch
 
 on:
   workflow_dispatch:
@@ -6,8 +6,9 @@ on:
     - cron: '0 22 * * *'  # Every day at 22:00 UTC
 
 jobs:
-  testflinger-vs-build-only:
-    runs-on: [self-hosted , testflinger]
+  testflinger-brcm-build-only:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+
     timeout-minutes: 300  # Time limit for this GitHub workflow job (not testflinger job!): 6 hours
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +18,7 @@ jobs:
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${{ github.workspace }}/.github/testflinger/vs_build_on_feature_noble_build.yaml
+          job-path: ${{ github.workspace }}/.github/testflinger/brcm_build_on_feature_noble_build.yaml
 
       - name: Display results
         id: get-results


### PR DESCRIPTION
- Update `Build vs image on feature_noble_build branch` workflow to `Build brcm image on feature_noble_build branch`
- Use private-endpoint GitHub runner (https://certification.canonical.com/docs/ops/github-runners-docs/), as encouraged by Testflinger team