### PR TITLE
Add socat.deb to all rocks

### DIFF
--- a/dockers/docker-database/rockcraft.yaml
+++ b/dockers/docker-database/rockcraft.yaml
@@ -39,6 +39,10 @@ services:
       DISTRO: "noble"
 
 parts:
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
   setup-database:
     plugin: dump
     source: .

--- a/dockers/docker-eventd/rockcraft.yaml
+++ b/dockers/docker-eventd/rockcraft.yaml
@@ -72,6 +72,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-eventd_1.0.0-0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-fpm-frr/rockcraft.yaml
+++ b/dockers/docker-fpm-frr/rockcraft.yaml
@@ -168,6 +168,11 @@ parts:
     source-type: deb
     source: ./debs/frr-snmp_8.5.4-sonic-0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-iccpd/rockcraft.yaml
+++ b/dockers/docker-iccpd/rockcraft.yaml
@@ -78,6 +78,11 @@ parts:
     source-type: deb
     source: ./debs/swss_1.0.0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-libsairedis_1.0.0_amd64:
     plugin: dump
     source-type: deb

--- a/dockers/docker-lldp/rockcraft.yaml
+++ b/dockers/docker-lldp/rockcraft.yaml
@@ -116,6 +116,11 @@ parts:
     source-type: deb
     source: ./debs/lldpd_1.0.16-1+deb12u1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:
@@ -143,7 +148,6 @@ parts:
       - libnl-genl-3-200
       - libnl-nf-3-200
       - libnl-cli-3-200
-      - socat
 
   install-python:
     plugin: python

--- a/dockers/docker-macsec/rockcraft.yaml
+++ b/dockers/docker-macsec/rockcraft.yaml
@@ -77,6 +77,11 @@ parts:
     source-type: deb
     source: ./debs/libdashapi_1.0.0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   # docker-swss-layer-noble packages
   install-swss_1.0.0_amd64:
     plugin: dump

--- a/dockers/docker-mux/rockcraft.yaml
+++ b/dockers/docker-mux/rockcraft.yaml
@@ -76,6 +76,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-linkmgrd_1.0.0-1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-nat/rockcraft.yaml
+++ b/dockers/docker-nat/rockcraft.yaml
@@ -134,6 +134,11 @@ parts:
     source-type: deb
     source: ./debs/libxtables12_1.8.9-2_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-iptables_1.8.9-2_amd64:
     plugin: dump
     source-type: deb

--- a/dockers/docker-orchagent/rockcraft.yaml
+++ b/dockers/docker-orchagent/rockcraft.yaml
@@ -247,6 +247,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-rsyslog-plugin_1.0.0-0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-platform-monitor/rockcraft.yaml
+++ b/dockers/docker-platform-monitor/rockcraft.yaml
@@ -152,6 +152,11 @@ parts:
     source-type: deb
     source: ./debs/ipmitool_1.8.19-9_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-router-advertiser/rockcraft.yaml
+++ b/dockers/docker-router-advertiser/rockcraft.yaml
@@ -71,6 +71,11 @@ parts:
   # docker-router-advertiser specfic packages
   # NONE
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-sflow/rockcraft.yaml
+++ b/dockers/docker-sflow/rockcraft.yaml
@@ -129,6 +129,11 @@ parts:
     source-type: deb
     source: ./debs/psample_1.1-1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-snmp/rockcraft.yaml
+++ b/dockers/docker-snmp/rockcraft.yaml
@@ -112,6 +112,11 @@ parts:
     source-type: deb
     source: ./debs/snmpd_5.9.4+dfsg-1.1ubuntu3.1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-sonic-gnmi/rockcraft.yaml
+++ b/dockers/docker-sonic-gnmi/rockcraft.yaml
@@ -92,6 +92,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-gnmi_0.1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-sonic-mgmt-framework/rockcraft.yaml
+++ b/dockers/docker-sonic-mgmt-framework/rockcraft.yaml
@@ -83,6 +83,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-mgmt-framework_1.0-01_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/dockers/docker-teamd/rockcraft.yaml
+++ b/dockers/docker-teamd/rockcraft.yaml
@@ -123,6 +123,11 @@ parts:
     source-type: deb
     source: ./debs/libteam-utils_1.31-1_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:

--- a/platform/broadcom/docker-syncd-brcm/rockcraft.yaml
+++ b/platform/broadcom/docker-syncd-brcm/rockcraft.yaml
@@ -100,6 +100,11 @@ parts:
     source-type: deb
     source: ./debs/libsaibcm_8.4.50.0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:


### PR DESCRIPTION
Previously the customized package socat was included in `docker-base-noble-sonic`, which is the base image of all feature docker images. That package needs to be added to all rocks' definition files.
