### PR TITLE
[build] use overlay2 for DinD by default

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -313,7 +313,7 @@ INCLUDE_FIPS ?= y
 ENABLE_FIPS ?= n
 
 # SONIC_SLAVE_DOCKER_DRIVER - set the sonic slave docker storage driver
-SONIC_SLAVE_DOCKER_DRIVER ?= vfs
+SONIC_SLAVE_DOCKER_DRIVER ?= overlay2
 
 # SONIC_OS_VERSION - sonic os version
 SONIC_OS_VERSION ?= 12


### PR DESCRIPTION
Backported from sonic-net/sonic-buildimage#19078 which improved performance and disk usage.