### PR TITLE
[build] Fix concurrency problems when building

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -25,6 +25,19 @@
 ## Include common functions
 . functions.sh
 
+## Unmount all mounts under and including FILESYSTEM_ROOT, deepest first.
+## This handles leftover docker overlay2 mounts, proc, sys, and bind mounts.
+cleanup_fsroot_mounts() {
+    local root
+    root=$(readlink -f "$FILESYSTEM_ROOT" 2>/dev/null) || root="$FILESYSTEM_ROOT"
+    [ -n "$root" ] || return 0
+    local mounts
+    mounts=$(awk -v root="$root" '$2 == root || $2 ~ "^"root"/" {print $2}' /proc/mounts | sort -r)
+    for mnt in $mounts; do
+        sudo umount "$mnt" 2>/dev/null || sudo umount -l "$mnt" 2>/dev/null || true
+    done
+}
+
 ## Enable debug output for script
 set -x -e
 
@@ -639,6 +652,9 @@ if [[ $RFS_SPLIT_LAST_STAGE == y ]]; then
     ## ensure proc is mounted
     sudo mount proc /proc -t proc || true
 
+    ## Clean up any stale mounts from a previous failed build
+    cleanup_fsroot_mounts
+
     sudo fuser -vm $FILESYSTEM_ROOT || true
     sudo rm -rf $FILESYSTEM_ROOT
     sudo unsquashfs -d $FILESYSTEM_ROOT $TARGET_PATH/$RFS_SQUASHFS_NAME
@@ -648,7 +664,7 @@ if [[ $RFS_SPLIT_LAST_STAGE == y ]]; then
     sudo mount --bind . .
     popd
 
-    trap_push 'sudo LANG=C chroot $FILESYSTEM_ROOT umount /proc || true'
+    trap_push cleanup_fsroot_mounts
     sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
 fi
 
@@ -826,6 +842,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT fuser -vm /proc
 sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /proc || true
 ## Wait fuser fully kill the processes
 sudo timeout 15s bash -c 'until LANG=C chroot $0 umount /proc; do sleep 1; done' $FILESYSTEM_ROOT || true
+
+## Umount all mounts under FILESYSTEM_ROOT (docker overlay2, bind mount, etc.)
+cleanup_fsroot_mounts
 
 ## Prepare empty directory to trigger mount move in initramfs-tools/mount_loop_root, implemented by patching
 sudo mkdir $FILESYSTEM_ROOT/host

--- a/slave.mk
+++ b/slave.mk
@@ -1373,7 +1373,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
 
 	# If another RFS with the same machine was already built, reuse it
 	if [ -n '$($*_RFS_REUSE_FROM)' ] && [ -f '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' ]; then
-		sudo cp '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
+		ln -s '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
 	else
 
 		$(eval installer=$($*_INSTALLER))

--- a/slave.mk
+++ b/slave.mk
@@ -517,6 +517,41 @@ endef
 $(foreach installer,$(SONIC_INSTALLERS),$(eval $(call rfs_define_target,$(installer))))
 $(foreach installer, $(SONIC_INSTALLERS), $(eval $(installer)_RFS_DEPENDS=$(call rfs_get_installer_dependencies,$(installer))))
 
+# Helper: return items from LIST whose _MACHINE equals MACHINE
+targets_for_machine = $(foreach t,$1,$(if $(filter $2,$($(t)_MACHINE)),$(t)))
+
+# assign_primary_rfs(MACHINE): among RFS targets for a given machine, mark
+# the first as the primary build and set RFS_REUSE_FROM on the rest so they
+# copy its squashfs output instead of running debootstrap again.
+define assign_primary_rfs
+$(eval _primary_rfs_$1 :=)
+$(foreach t,$(call targets_for_machine,$(SONIC_RFS_TARGETS),$1),\
+	$(if $(_primary_rfs_$1),\
+		$(eval $(t)_RFS_REUSE_FROM := $(_primary_rfs_$1)),\
+		$(eval _primary_rfs_$1 := $(t))))
+endef
+
+# Apply assign_primary_rfs for each unique machine
+$(foreach m,\
+	$(sort $(foreach t,$(SONIC_RFS_TARGETS),$($(t)_MACHINE))),\
+	$(call assign_primary_rfs,$m))
+
+# serialize_installers(MACHINE): chain installer targets for a given machine
+# with order-only dependencies so they build sequentially, avoiding races on
+# shared intermediate files (fs.squashfs, fs.zip, etc.).
+define serialize_installers
+$(eval _prev_inst :=)
+$(foreach i,$(call targets_for_machine,$(SONIC_INSTALLERS),$1),\
+	$(if $(_prev_inst),\
+		$(eval $(TARGET_PATH)/$(i): | $(TARGET_PATH)/$(_prev_inst)))\
+		$(eval _prev_inst := $(i)))
+endef
+
+# Apply serialize_installers for each unique machine
+$(foreach m,\
+	$(sort $(foreach i,$(SONIC_INSTALLERS),$($(i)_MACHINE))),\
+	$(call serialize_installers,$m))
+
 SONIC_TARGET_LIST += $(addprefix RFS_TARGETS-$(TARGET_PATH)/, $(SONIC_RFS_TARGETS))
 
 # Overwrite the buildinfo in slave container
@@ -1327,6 +1362,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
         build_debian.sh \
         $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL)) \
         $$(addprefix $(TARGET_PATH)/,$$($$*_DEPENDENT_RFS)) \
+        $$(if $$($$*_RFS_REUSE_FROM),$$(addprefix $(TARGET_PATH)/,$$($$*_RFS_REUSE_FROM))) \
         $(call dpkg_depend,$(TARGET_PATH)/%.dep)
 	$(HEADER)
 
@@ -1334,6 +1370,11 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
 
 	# Skip building the target if it is already loaded from cache
 	if [ -z '$($*_CACHE_LOADED)' ] ; then
+
+	# If another RFS with the same machine was already built, reuse it
+	if [ -n '$($*_RFS_REUSE_FROM)' ] && [ -f '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' ]; then
+		sudo cp '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
+	else
 
 		$(eval installer=$($*_INSTALLER))
 		$(eval machine=$($*_MACHINE))
@@ -1370,6 +1411,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
 		MASTER_KUBERNETES_VERSION=$(MASTER_KUBERNETES_VERSION) \
 		MASTER_CRI_DOCKERD=$(MASTER_CRI_DOCKERD) \
 			./build_debian.sh $(LOG)
+
+	fi
 
 		$(call SAVE_CACHE,$*,$@)
 

--- a/slave.mk
+++ b/slave.mk
@@ -1373,7 +1373,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
 
 	# If another RFS with the same machine was already built, reuse it
 	if [ -n '$($*_RFS_REUSE_FROM)' ] && [ -f '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' ]; then
-		ln -s '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
+		ln -sf '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
 	else
 
 		$(eval installer=$($*_INSTALLER))

--- a/slave.mk
+++ b/slave.mk
@@ -1373,7 +1373,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_RFS_TARGETS)) : $(TARGET_PATH)/% : \
 
 	# If another RFS with the same machine was already built, reuse it
 	if [ -n '$($*_RFS_REUSE_FROM)' ] && [ -f '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' ]; then
-		ln -sf '$(TARGET_PATH)/$($*_RFS_REUSE_FROM)' '$@'
+		ln -sf '$($*_RFS_REUSE_FROM)' '$@'
 	else
 
 		$(eval installer=$($*_INSTALLER))


### PR DESCRIPTION

## Why
When building multiple SONiC images for the same machine in parallel, several race conditions can occur:

- Redundant debootstrap runs — Multiple RFS targets for the same machine each run a full debootstrap, wasting significant build time.
- Shared intermediate file races — Installer targets for the same machine write to shared files (fs.squashfs, fs.zip etc.) concurrently, causing corrupted outputs.
- Stale mount leaks — If a previous build fails, leftover docker overlay2 / proc / bind mounts under `FILESYSTEM_ROOT` are not cleaned up, causing subsequent builds to fail on rm -rf.

## What
### slave.mk
- Add `targets_for_machine` helper to filter targets by machine name.
- Add `assign_primary_rfs` — for RFS targets sharing the same machine, pick the first as the primary build; the rest copy its squashfs via `RFS_REUSE_FROM` instead of running debootstrap again.
- Add `serialize_installers` — chain installer targets for the same machine with order-only dependencies so they build sequentially.
### build_debian.sh

- Add `cleanup_fsroot_mounts()` function that unmounts all mounts under `FILESYSTEM_ROOT` (overlay2, proc, bind mounts, etc.) in deepest-first order.
- Call it before `rm -rf $FILESYSTEM_ROOT` to clean up stale mounts from previous failed builds.
- Register it as a trap handler for cleanup on exit.
- Remove redundant standalone `trap_push umount /proc` since `cleanup_fsroot_mounts` already covers it.
## How to verify
`make all` with a SONIC_BUILD_JOBS which is large enough.

Build multiple image targets for the same machine in parallel and confirm:
- Only one debootstrap runs per machine; others reuse the squashfs.
- No race conditions on shared intermediate files.
- A failed build followed by a retry does not fail on stale mounts.
