### PR TITLE
Add dynamic services to dhcp_relay rock

### DIFF
--- a/build_rocks.sh
+++ b/build_rocks.sh
@@ -39,6 +39,7 @@ do
     cp -r target/debs/noble/*  $rockitem/debs/
     cp -r target/files/noble/* $rockitem/files/
     cp -r target/python-wheels/noble/* $rockitem/python-wheels/
+    echo "export IMAGE_VERSION=$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse HEAD)" > $rockitem/envs
 
     pushd $rockitem
 
@@ -56,5 +57,5 @@ do
     popd 
 
     docker rmi -f $rockname:latest
-
+    rm $rockitem/envs
 done

--- a/dockers/docker-dhcp-relay/rock_init.sh
+++ b/dockers/docker-dhcp-relay/rock_init.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+source /usr/share/sonic/templates/envs
+
+LAYER_FILE="/usr/share/sonic/templates/syslog-layer.yaml"
+pebble add syslog-layer --combine $LAYER_FILE
+pebble replan
+
 # Generate supervisord config file
 mkdir -p /etc/supervisor/conf.d/
 
@@ -17,3 +23,38 @@ sonic-cfggen $CFGGEN_PARAMS
 
 # Make the script that waits for all interfaces to come up executable
 chmod +x /usr/bin/wait_for_intf.sh
+
+# ============= Below is previous start.sh ======================
+if [ "${RUNTIME_OWNER}" == "" ]; then
+    RUNTIME_OWNER="kube"
+fi
+
+CTR_SCRIPT="/usr/share/sonic/scripts/container_startup.py"
+if test -f ${CTR_SCRIPT}
+then
+    ${CTR_SCRIPT} -f dhcp_relay -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}
+fi
+
+TZ=$(cat /etc/timezone)
+rm -rf /etc/localtime
+ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+# If pebble has dhcp relay agent services...
+AGENTSERVICESV4=$(pebble services | grep -c "^isc-dhcpv4-relay")
+AGENTSERVICESV6=$(pebble services | grep -c "^dhcp6relay")
+if [ $AGENTSERVICESV4 -gt 0 ] || [ $AGENTSERVICESV6 -gt 0 ]; then
+    # Wait for all interfaces to come up and be assigned IPv4 addresses before
+    # starting the DHCP relay agent(s). If an interface the relay should listen
+    # on is down, the relay agent will not start. If an interface the relay
+    # should listen on is up but does not have an IP address assigned when the
+    # relay agent starts, it will not listen or send on that interface for the
+    # lifetime of the process.
+    /usr/bin/wait_for_intf.sh
+fi
+
+pebble start dhcprelayd
+
+layer_path=$(python3 /usr/bin/supervisord_ini_to_pebble_yml.py)
+
+pebble add dynamic_layer --combine $layer_path
+pebble replan

--- a/dockers/docker-dhcp-relay/rock_init.sh
+++ b/dockers/docker-dhcp-relay/rock_init.sh
@@ -54,7 +54,7 @@ fi
 
 pebble start dhcprelayd
 
-layer_path=$(python3 /usr/bin/supervisord_ini_to_pebble_yml.py)
+layer_path=$(python3 /usr/bin/supervisord_ini_to_pebble_yml.py /etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf)
 
 pebble add dynamic_layer --combine $layer_path
 pebble replan

--- a/dockers/docker-dhcp-relay/rockcraft.yaml
+++ b/dockers/docker-dhcp-relay/rockcraft.yaml
@@ -33,8 +33,6 @@ services:
   dhcprelayd:
     command: dhcprelayd
     override: replace
-    startup: enabled
-    after: [ rsyslogd ]
 
 # For meeting requirement R2, simply don't specify any entrypoint (aka "services")
 

--- a/dockers/docker-dhcp-relay/rockcraft.yaml
+++ b/dockers/docker-dhcp-relay/rockcraft.yaml
@@ -141,6 +141,7 @@ parts:
       - click
       - psutil
       - lxml
+      - setuptools
     stage-packages:
       - python3-venv
 

--- a/dockers/docker-dhcp-relay/rockcraft.yaml
+++ b/dockers/docker-dhcp-relay/rockcraft.yaml
@@ -17,23 +17,21 @@ platforms:
 
 services:
   init:
-    command: bash -c "/usr/bin/rock_init.sh && touch /tmp/init_ok"
+    command: /usr/bin/rock_init.sh
     override: replace
     startup: enabled
     on-success: ignore
+    on-failure: ignore
+    environment:
+      DEBIAN_FRONTEND: "noninteractive"
+      IMAGENAME: "docker-dhcp-relay"
+      DISTRO: "noble"
   rsyslogd:
-    command: bash -c "test -f /tmp/init_ok && exec /usr/sbin/rsyslogd -n -iNONE"
+    command: /usr/sbin/rsyslogd -n -iNONE
     override: replace
     startup: enabled
-  start:
-    command: bash -c "/usr/bin/start.sh && touch /tmp/start_ok"
-    override: replace
-    startup: enabled
-    after: [ rsyslogd ]
-    on-success: ignore
-    on-failure: restart
   dhcprelayd:
-    command: bash -c "test -f /tmp/zsocket_ok && exec /usr/local/bin/dhcprelayd"
+    command: dhcprelayd
     override: replace
     startup: enabled
     after: [ rsyslogd ]
@@ -97,6 +95,11 @@ parts:
     source-type: deb
     source: ./debs/sonic-rsyslog-plugin_1.0.0-0_amd64.deb
 
+  install-socat:
+    plugin: dump
+    source-type: deb
+    source: ./debs/socat_1.7.4.1-3_amd64.deb
+
   install-packages:
     plugin: nil
     stage-packages:
@@ -119,6 +122,7 @@ parts:
       - libnl-genl-3-200
       - libnl-nf-3-200
       - libnl-cli-3-200
+      - explain
 
   install-python:
     plugin: python
@@ -135,14 +139,10 @@ parts:
       - jinjanator
       # docker-dhcp-relay specific packages
       - click
-      - supervisor==4.2.5
-      - supervisord-dependent-startup==1.4.0
       - psutil
       - lxml
     stage-packages:
       - python3-venv
-    organize:
-      bin/supervisord: usr/local/bin/supervisord
 
   install-common-files:
     plugin: nil
@@ -178,13 +178,14 @@ parts:
 
       mkdir -p etc/sysctl.d/
       cp ${CRAFT_PROJECT_DIR}/files/sysctl-net.conf               etc/sysctl.d/
-      cp ${CRAFT_PROJECT_DIR}/files/supervisor-proc-exit-listener usr/bin/
+      cp ${CRAFT_PROJECT_DIR}/files/syslog-layer.yaml             usr/share/sonic/templates/
 
       # docker-dhcp-relay specifc
       mkdir -p usr/bin
-      cp ${CRAFT_PROJECT_DIR}/docker_init.sh          usr/bin/
-      cp ${CRAFT_PROJECT_DIR}/rock_init.sh            usr/bin/
-      cp ${CRAFT_PROJECT_DIR}/start.sh                usr/bin/
+      cp ${CRAFT_PROJECT_DIR}/docker_init.sh                    usr/bin/
+      cp ${CRAFT_PROJECT_DIR}/rock_init.sh                      usr/bin/
+      cp ${CRAFT_PROJECT_DIR}/start.sh                          usr/bin/
+      cp ${CRAFT_PROJECT_DIR}/supervisord_ini_to_pebble_yml.py  usr/bin/
 
       cp ${CRAFT_PROJECT_DIR}/port-name-alias-map.txt.j2  usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/wait_for_intf.sh.j2         usr/share/sonic/templates/
@@ -192,6 +193,7 @@ parts:
       cp ${CRAFT_PROJECT_DIR}/dhcpv4-relay.agents.j2      usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/dhcpv6-relay.agents.j2      usr/share/sonic/templates/
       cp ${CRAFT_PROJECT_DIR}/dhcp-relay.monitors.j2      usr/share/sonic/templates/
+      cp ${CRAFT_PROJECT_DIR}/envs                        usr/share/sonic/templates/
 
       mkdir -p cli
       cp -r ${CRAFT_PROJECT_DIR}/cli/*                    cli/

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -5,7 +5,7 @@ import yaml
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("Usage: python3 supervisord_ini_to_pebble_yml.py <path_to_supervisord.conf>")
+        print("Usage: python3 supervisord_ini_to_pebble_yml.py /path/to/supervisord.conf")
         return 1
     
     config_file = sys.argv[1]

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -30,4 +30,4 @@ def main() -> int:
 
 
 if __name__ == '__main__':
-    raise SystemExit(main())
+    sys.exit(main())

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -1,0 +1,27 @@
+import configparser
+import tempfile
+import yaml
+
+def main() -> int:
+    config = configparser.ConfigParser()
+    with open('supervisord.conf', 'r', encoding='utf-8') as f:
+        config.read_file(f)
+
+    services = {}
+    for section in config.sections():
+        if section.startswith('program:isc-dhcpv4') or section.startswith('program:dhcpmon-'):
+            svc_name = section[8:]
+            svc = {'command': config.get(section, 'command'), 'override': 'replace', 'startup': 'enabled'}
+            services[svc_name] = svc
+
+    with tempfile.NamedTemporaryFile(prefix='pebble-layer-', suffix='.yaml', delete=False, mode='w', encoding='utf-8') as f:
+        output = {'services': services}
+        yaml.safe_dump(output, f, width=float("inf"))
+        temp_path = f.name
+
+    print(temp_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -16,7 +16,7 @@ def main() -> int:
     services = {}
     for section in config.sections():
         if section.startswith('program:isc-dhcpv4') or section.startswith('program:dhcpmon-'):
-            svc_name = section[8:]
+            svc_name = section[len('program:'):]
             svc = {'command': config.get(section, 'command'), 'override': 'replace', 'startup': 'enabled'}
             services[svc_name] = svc
 

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -1,10 +1,16 @@
 import configparser
+import sys
 import tempfile
 import yaml
 
 def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python3 supervisord_ini_to_pebble_yml.py <path_to_supervisord.conf>")
+        return 1
+    
+    config_file = sys.argv[1]
     config = configparser.ConfigParser()
-    with open('supervisord.conf', 'r', encoding='utf-8') as f:
+    with open(config_file, 'r', encoding='utf-8') as f:
         config.read_file(f)
 
     services = {}

--- a/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
+++ b/dockers/docker-dhcp-relay/supervisord_ini_to_pebble_yml.py
@@ -22,7 +22,7 @@ def main() -> int:
 
     with tempfile.NamedTemporaryFile(prefix='pebble-layer-', suffix='.yaml', delete=False, mode='w', encoding='utf-8') as f:
         output = {'services': services}
-        yaml.safe_dump(output, f, width=float("inf"))
+        yaml.safe_dump(output, f)
         temp_path = f.name
 
     print(temp_path)


### PR DESCRIPTION
This PR is to replace [PR#27](https://github.com/canonical/sonic-buildimage/pull/27) 

Improve dhcp_relay rock packaging:
- Generate pebble config of dynamic services from supervisord config
- Merge the start.sh into init.sh
- Remove supervisord packages
- Remove the ugly workaround for service start order control (`tmp/init_ok` stuff) 
- Add socat for dhcp_relay 